### PR TITLE
Set default for language column

### DIFF
--- a/db/migrate/202302021080041_set_language_default.rb
+++ b/db/migrate/202302021080041_set_language_default.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Pro Natura. This file is part of
+#  hitobito_pro_natura and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pro_natura.
+
+class SetLanguageDefault < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default(:people, :language, from: nil, to: 'de')
+  end
+end


### PR DESCRIPTION
Closes: https://github.com/hitobito/hitobito/issues/1978

So the language column was already addressed once in a migration:
https://github.com/hitobito/hitobito_pro_natura/blob/master/db/migrate/20220309114741_adjust_language_according_to_core.rb
The idea was great: Add a null constraint to the column and default to 'de'
However if you look into the api docs for `change_column_null`, it shows that the last argument **does not** set a default on the column. It replaces all previous NULL values to the given argument.
Thus setting a default was still needed